### PR TITLE
Check null pointers returned by strdup and kstrdup

### DIFF
--- a/arch/arm/mach-mmp/sram.c
+++ b/arch/arm/mach-mmp/sram.c
@@ -95,7 +95,7 @@ static int sram_probe(struct platform_device *pdev)
 	info->granularity = pdata->granularity;
 
 	info->gpool = gen_pool_create(ilog2(info->granularity), -1);
-	if (!info->gpool) {
+	if (!info->gpool || (!info->pool_name && pdata->pool_name)) {
 		dev_err(&pdev->dev, "create pool failed\n");
 		ret = -ENOMEM;
 		goto create_pool_err;

--- a/arch/arm/mach-versatile/versatile_dt.c
+++ b/arch/arm/mach-versatile/versatile_dt.c
@@ -326,6 +326,12 @@ static void __init versatile_dt_pci_init(void)
 	newprop->name = kstrdup("status", GFP_KERNEL);
 	newprop->value = kstrdup("disabled", GFP_KERNEL);
 	newprop->length = sizeof("disabled");
+	if (!newprop->name || !newprop->value) {
+		kfree(newprop->name);
+		kfree(newprop->value);
+		kfree(newprop);
+		return;
+	}
 	of_update_property(np, newprop);
 
 	pr_info("Not plugged into PCI backplane!\n");

--- a/arch/um/os-Linux/drivers/tuntap_user.c
+++ b/arch/um/os-Linux/drivers/tuntap_user.c
@@ -182,6 +182,11 @@ static int tuntap_open(void *data)
 		}
 
 		pri->dev_name = uml_strdup(buffer);
+		if (pri->dev_name == NULL) {
+			printk(UM_KERN_ERR "tuntap_open : out of memory\n");
+			free_output_buffer(buffer);
+			return -ENOMEM;
+		}
 		output += IFNAMSIZ;
 		printk("%s", output);
 		free_output_buffer(buffer);

--- a/arch/x86/entry/vdso/vdso2c.c
+++ b/arch/x86/entry/vdso/vdso2c.c
@@ -227,6 +227,10 @@ int main(int argc, char **argv)
 	 * generate raw output insted.
 	 */
 	name = strdup(argv[3]);
+	if (!name) {
+		printf("Out of memory\n");
+		return 1;
+	}
 	namelen = strlen(name);
 	if (namelen >= 3 && !strcmp(name + namelen - 3, ".so")) {
 		name = NULL;

--- a/drivers/crypto/msm/ice.c
+++ b/drivers/crypto/msm/ice.c
@@ -514,6 +514,10 @@ static int qcom_ice_parse_clock_info(struct platform_device *pdev,
 		}
 		clki->max_freq = clkfreq[i];
 		clki->name = kstrdup(name, GFP_KERNEL);
+		if (!clki->name && name) {
+			ret = -ENOMEM;
+			goto out;
+		}
 		list_add_tail(&clki->list, &ice_dev->clk_list_head);
 	}
 out:

--- a/drivers/fmc/fmc-chardev.c
+++ b/drivers/fmc/fmc-chardev.c
@@ -141,6 +141,10 @@ static int fc_probe(struct fmc_device *fmc)
 	fc->misc.minor = MISC_DYNAMIC_MINOR;
 	fc->misc.fops = &fc_fops;
 	fc->misc.name = kstrdup(dev_name(&fmc->dev), GFP_KERNEL);
+	if (!fc->misc.name && dev_name(&fmc->dev)) {
+		kfree(fc);
+		return -ENOMEM;
+	}
 
 	ret = misc_register(&fc->misc);
 	if (ret < 0)

--- a/drivers/fmc/fmc-match.c
+++ b/drivers/fmc/fmc-match.c
@@ -96,6 +96,10 @@ int fmc_fill_id_info(struct fmc_device *fmc)
 
 	/* Create the short name (FIXME: look in sdb as well) */
 	fmc->mezzanine_name = kstrdup(fmc->id.product_name, GFP_KERNEL);
+	if (!fmc->mezzanine_name && fmc->id.product_name) {
+		pr_info("      out of memory\n");
+		goto out;
+	}	
 
 out:
 	if (allocated) {


### PR DESCRIPTION
The lib function `strdup` and `kstrdup` may return NULL on memory allocation failures.
Therefore, I added checks for calls to `strdup` and `kstrdup` that were not checked for NULL.